### PR TITLE
Updated pom.xml by upgrading the jsch plugin to V0.1.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ Based on the cool scp plugin.</description>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.54.1</version>
+			<version>0.1.55</version>
 		</dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This change is to fix the following issue
[JENKINS-56031](https://issues.jenkins-ci.org/browse/JENKINS-56031) - SSH plugin rains intermittently with because of issue with JSch

